### PR TITLE
Fix the eval code

### DIFF
--- a/pipeline/eval.py
+++ b/pipeline/eval.py
@@ -84,7 +84,7 @@ class AgentLMInfer(ModelInfer):
         max_length = 2048
         
         input_ids = self.tokenizer(input,return_tensors='pt',).input_ids
-        generate_ids = self.model.generate(input_ids,max_length=max_length,eos_token_id=eos_token_id)
+        generate_ids = self.model.generate(input_ids.to('cuda'),max_length=max_length,eos_token_id=eos_token_id)
         response = self.tokenizer.batch_decode(generate_ids,skip_special_tokens=True)
         response = response[0]
         response = response.split(conv.roles[1])[-1].strip()


### PR DESCRIPTION
Data and the mode have to be in the same device:

It produces the error when the main.py is executed on eval mode:

```
  File "/home/ivan/research/BadAgent/pipeline/eval.py", line 87, in chat
    generate_ids = self.model.generate(input_ids,max_length=max_length,eos_token_id=eos_token_id)

RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument index in method wrapper_CUDA__index_select)
```

It has be fixed:
input_ids -> input_ids.to('cuda')